### PR TITLE
Feature for automatically creating database from GraphQL Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ arangodb:
   database: <database-name>
 ```
 
+You can also auto create your database, collections and indexes from your GraphQL schema by enabling the following 
+property in the application.yaml file
+
+```yaml
+arangodb:
+  autoCreate: true
+```
+
+
 ## Adding graphiql
 
 To add GraphiQL to your project to give you a web UI to submit queries - simply add the following to you POM.

--- a/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/ArangoGraphQLAutoConfiguration.java
+++ b/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/ArangoGraphQLAutoConfiguration.java
@@ -132,7 +132,7 @@ public class ArangoGraphQLAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(name="arango.autoCreate", havingValue = "true")
+    @ConditionalOnProperty(name="arangodb.autoCreate", havingValue = "true")
     public AutomaticDatabaseObjectCreator automaticDatabaseObjectCreator(DatabaseObjectCreator databaseObjectCreator){
         return new AutomaticDatabaseObjectCreator(databaseObjectCreator);
     }

--- a/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/ArangoGraphQLConfigurationProperties.java
+++ b/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/ArangoGraphQLConfigurationProperties.java
@@ -106,6 +106,10 @@ public class ArangoGraphQLConfigurationProperties {
      */
     private Protocol protocol = ArangoDefaults.DEFAULT_NETWORK_PROTOCOL;
 
+    /**
+     * Whether we should attempt to auto create ArangoDB databases, collections and indexes from the GraphQL schema
+     */
+    private boolean autoCreate;
 
     public String getSchemaLocation() {
         return schemaLocation;
@@ -203,4 +207,12 @@ public class ArangoGraphQLConfigurationProperties {
         this.protocol = protocol;
     }
 
+
+    public boolean isAutoCreate() {
+        return autoCreate;
+    }
+
+    public void setAutoCreate(boolean autoCreate) {
+        this.autoCreate = autoCreate;
+    }
 }

--- a/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/ArangoGraphQLConfigurationProperties.java
+++ b/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/ArangoGraphQLConfigurationProperties.java
@@ -115,91 +115,91 @@ public class ArangoGraphQLConfigurationProperties {
         this.schemaLocation = schemaLocation;
     }
 
-    public final String getDatabase() {
+    public String getDatabase() {
         return database;
     }
 
-    public final void setDatabase(final String database) {
+    public void setDatabase(final String database) {
         this.database = database;
     }
 
-    public final String getUser() {
+    public String getUser() {
         return user;
     }
 
-    public final void setUser(final String user) {
+    public void setUser(final String user) {
         this.user = user;
     }
 
-    public final String getPassword() {
+    public String getPassword() {
         return password;
     }
 
-    public final void setPassword(final String password) {
+    public void setPassword(final String password) {
         this.password = password;
     }
 
-    public final Collection<String> getHosts() {
+    public Collection<String> getHosts() {
         return hosts;
     }
 
-    public final void setHosts(final Collection<String> hosts) {
+    public void setHosts(final Collection<String> hosts) {
         this.hosts = hosts;
     }
 
-    public final Integer getTimeout() {
+    public  Integer getTimeout() {
         return timeout;
     }
 
-    public final void setTimeout(final Integer timeout) {
+    public void setTimeout(final Integer timeout) {
         this.timeout = timeout;
     }
 
-    public final Boolean getUseSsl() {
+    public Boolean getUseSsl() {
         return useSsl;
     }
 
-    public final void setUseSsl(final Boolean useSsl) {
+    public void setUseSsl(final Boolean useSsl) {
         this.useSsl = useSsl;
     }
 
-    public final Integer getMaxConnections() {
+    public Integer getMaxConnections() {
         return maxConnections;
     }
 
-    public final void setMaxConnections(final Integer maxConnections) {
+    public void setMaxConnections(final Integer maxConnections) {
         this.maxConnections = maxConnections;
     }
 
-    public final Long getConnectionTtl() {
+    public Long getConnectionTtl() {
         return connectionTtl;
     }
 
-    public final void setConnectionTtl(final Long connectionTtl) {
+    public void setConnectionTtl(final Long connectionTtl) {
         this.connectionTtl = connectionTtl;
     }
 
-    public final Boolean getAcquireHostList() {
+    public Boolean getAcquireHostList() {
         return acquireHostList;
     }
 
-    public final void setAcquireHostList(final Boolean acquireHostList) {
+    public void setAcquireHostList(final Boolean acquireHostList) {
         this.acquireHostList = acquireHostList;
     }
 
-    public final LoadBalancingStrategy getLoadBalancingStrategy() {
+    public LoadBalancingStrategy getLoadBalancingStrategy() {
         return loadBalancingStrategy;
     }
 
-    public final void setLoadBalancingStrategy(final LoadBalancingStrategy loadBalancingStrategy) {
+    public void setLoadBalancingStrategy(final LoadBalancingStrategy loadBalancingStrategy) {
         this.loadBalancingStrategy = loadBalancingStrategy;
     }
 
-    public final Protocol getProtocol() {
+    public Protocol getProtocol() {
         return protocol;
     }
 
-    public final void setProtocol(final Protocol protocol) {
+    public void setProtocol(final Protocol protocol) {
         this.protocol = protocol;
     }
 

--- a/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/AutomaticDatabaseObjectCreator.java
+++ b/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/AutomaticDatabaseObjectCreator.java
@@ -1,4 +1,26 @@
 package com.arangodb.graphql.spring.boot.autoconfigure;
 
+import com.arangodb.ArangoDB;
+import com.arangodb.graphql.create.DatabaseObjectCreator;
+import graphql.GraphQL;
+
+import javax.annotation.PostConstruct;
+
 public class AutomaticDatabaseObjectCreator {
+
+    private final DatabaseObjectCreator databaseObjectCreator;
+
+    public AutomaticDatabaseObjectCreator(DatabaseObjectCreator databaseObjectCreator){
+        this.databaseObjectCreator = databaseObjectCreator;
+    }
+
+    @PostConstruct
+    public void init(){
+
+        databaseObjectCreator.createDatabase();
+        databaseObjectCreator.createCollections();
+        databaseObjectCreator.createIndexes();
+
+    }
+
 }

--- a/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/AutomaticDatabaseObjectCreator.java
+++ b/src/main/java/com/arangodb/graphql/spring/boot/autoconfigure/AutomaticDatabaseObjectCreator.java
@@ -1,0 +1,4 @@
+package com.arangodb.graphql.spring.boot.autoconfigure;
+
+public class AutomaticDatabaseObjectCreator {
+}

--- a/src/test/java/com/arangodb/graphql/spring/boot/DatabaseAutoCreateTest.java
+++ b/src/test/java/com/arangodb/graphql/spring/boot/DatabaseAutoCreateTest.java
@@ -1,0 +1,33 @@
+package com.arangodb.graphql.spring.boot;
+
+import com.arangodb.graphql.create.DatabaseObjectCreator;
+import com.arangodb.graphql.spring.boot.autoconfigure.AutomaticDatabaseObjectCreator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringRunner.class)
+public class DatabaseAutoCreateTest {
+
+    @Configuration
+    @Import(AutomaticDatabaseObjectCreator.class) // A @Component injected with ExampleService
+    static class Config {
+    }
+
+    @MockBean
+    private DatabaseObjectCreator databaseObjectCreator;
+
+    @Test
+    public void autoCreateInvoked(){
+        verify(databaseObjectCreator).createDatabase();
+        verify(databaseObjectCreator).createCollections();
+        verify(databaseObjectCreator).createIndexes();;
+    }
+}

--- a/src/test/java/com/arangodb/graphql/spring/boot/DatabaseDisableAutoCreateTest.java
+++ b/src/test/java/com/arangodb/graphql/spring/boot/DatabaseDisableAutoCreateTest.java
@@ -1,0 +1,33 @@
+package com.arangodb.graphql.spring.boot;
+
+import com.arangodb.graphql.create.DatabaseObjectCreator;
+import com.arangodb.graphql.spring.boot.autoconfigure.AutomaticDatabaseObjectCreator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles("city")
+@SpringBootTest
+public class DatabaseDisableAutoCreateTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test(expected = NoSuchBeanDefinitionException.class)
+    public void autoCreateDisabled() {
+        applicationContext.getBean(AutomaticDatabaseObjectCreator.class);
+    }
+}


### PR DESCRIPTION
Optional feature controlled by arangodb.autoCreate property that when enabled will attempt to create databases, collections and indexes on the configured database server, from the GraphQL schema if they do not exist.